### PR TITLE
File DAO Empty String Bug Fix

### DIFF
--- a/src/data_access/FileUserDataAccessObject.java
+++ b/src/data_access/FileUserDataAccessObject.java
@@ -42,8 +42,17 @@ public class FileUserDataAccessObject implements LoginUserDataAccessInterface,
                     // Getting user attributes from col
                     String username = col[headers.get("username")];
                     String password = col[headers.get("password")];
-                    List<String> healthPreferences = new ArrayList<>(Arrays.asList(col[headers.get("healthPreferences")].split("/")));
-                    List<String> dishType = new ArrayList<>(Arrays.asList(col[headers.get("dishType")].split("/")));
+
+                    String healthPreferencesCol = col[headers.get("healthPreferences")];
+                    String dishTypeCol = col[headers.get("dishType")];
+
+                    List<String> healthPreferences = healthPreferencesCol.isEmpty() ?
+                            new ArrayList<>() :
+                            new ArrayList<>(Arrays.asList(healthPreferencesCol.split("/")));
+                    List<String> dishType = dishTypeCol.isEmpty() ?
+                            new ArrayList<>() :
+                            new ArrayList<>(Arrays.asList(dishTypeCol.split("/")));
+
                     int[] calRange = convertStringArrToNumArr(col[headers.get("calRange")].split("-"));
                     int[] fatRange = convertStringArrToNumArr(col[headers.get("fatRange")].split("-"));
                     int[] proteinRange = convertStringArrToNumArr(col[headers.get("proteinRange")].split("-"));


### PR DESCRIPTION
**Bug**: If users created an account, and did not select any of the list preferences, and saved their preferences, the next time they opened the app, the empty preferences, which is saved as an empty string, is parsed and the empty string becomes an element of the preference list. 
**Fix**: Check for empty preferences, and create an empty array list of the preference is empty.